### PR TITLE
Add support PKG_CONFIG_PATH/PKG_CONFIG_LIBDIR env vars for libcrypto and libssl

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -30,7 +30,7 @@ noinst_HEADERS = buffer.h \
 ccnetincludedir = $(includedir)/ccnet
 ccnetinclude_DATA = ccnet-object.h
 
-libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB @PTHREAD_CFLAGS@
+libccnet_la_CPPFLAGS = $(AM_CPPFLAGS) -DCCNET_LIB @PTHREAD_CFLAGS@ @SSL_CFLAGS@
 
 libccnet_la_SOURCES = ccnet-client.c packet-io.c libccnet_utils.c \
 	message.c proc-factory.c \
@@ -53,6 +53,8 @@ libccnet_la_LIBADD = @PTHREAD_LIBS@ @GLIB2_LIBS@ @GOBJECT_LIBS@ @LIB_GDI32@ \
 
 
 noinst_LTLIBRARIES = libccnetd.la
+
+libccnetd_la_CPPFLAGS = $(AM_CPPFLAGS) @SSL_CFLAGS@
 
 libccnetd_la_SOURCES = utils.c db.c job-mgr.c \
 	rsa.c bloom-filter.c marshal.c net.c timer.c ccnet-session-base.c \

--- a/net/server/Makefile.am
+++ b/net/server/Makefile.am
@@ -7,6 +7,7 @@ AM_CPPFLAGS = @GLIB2_CFLAGS@ @GOBJECT_CFLAGS@ \
 	-I$(top_builddir)/include \
 	-I$(top_builddir)/lib \
 	@SEARPC_CFLAGS@ \
+	@SSL_CFLAGS@ \
 	-Wall
 
 bin_PROGRAMS = ccnet-server

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I$(top_srcdir)/include @GLIB2_CFLAGS@ -I$(top_srcdir)/lib
+AM_CPPFLAGS = -I$(top_srcdir)/include @GLIB2_CFLAGS@ -I$(top_srcdir)/lib @SSL_CFLAGS@
 
 bin_PROGRAMS = ccnet-init
 


### PR DESCRIPTION
This enables support for compiling ccnet-server using an OpenSSL version installed outside the system's default prefix. Until ccnet-server supports openssl 1.1.0, this is required to compile for example on Archlinux where the current openssl 1.0.2 package will soon be upgraded to 1.1.0, and the future 1.0.2 package's files will go into /usr/lib/openssl-1.0.

To use this, execute `export PKG_CONFIG_PATH=/usr/lib/openssl-1.0/lib/pkgconfig` prior to running `autogen.sh`.