### PR TITLE
add ccnet to list of dependencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,7 @@ The following packages are required to build ccnet:
 
     valac >= 0.8
     libsearpc
+    ccnet
     libmysqlclient-dev for compiling ccnet server
 
 Compile


### PR DESCRIPTION
In v7.1.1 ccnet-server fails during configure if libccnet is not present:

```
checking for libccnet >= 0.9.3... no                                                                                                                                                         
configure: error: Package requirements (libccnet >= 0.9.3) were not met:

No package 'libccnet' found
```

Making ccnet available as a build input fixes the issue. 