### PR TITLE
Connection to Mysql server only Unix socket

### DIFF
--- a/net/common/ccnet-db.c
+++ b/net/common/ccnet-db.c
@@ -539,13 +539,13 @@ mysql_db_new (const char *host,
 {
     MySQLDB *db = g_new0 (MySQLDB, 1);
 
-    db->host = g_strdup (host);
+    if (host) {db->host = g_strdup (host);} else {db->host = NULL;}
     db->user = g_strdup (user);
     db->password = g_strdup (password);
     db->port = port;
     db->db_name = g_strdup(db_name);
-    db->unix_socket = g_strdup(unix_socket);
-    db->use_ssl = use_ssl;
+    if (unix_socket) {db->unix_socket = g_strdup(unix_socket);} else {db->unix_socket = NULL;}
+    if (use_ssl) {db->use_ssl = use_ssl;} else {db->use_ssl = NULL;}
     db->charset = g_strdup(charset);
 
     mysql_library_init (0, NULL, NULL);

--- a/net/server/server-session.c
+++ b/net/server/server-session.c
@@ -138,10 +138,6 @@ static int init_mysql_database (CcnetSession *session)
     passwd = ccnet_key_file_get_string (session->keyf, "Database", "PASSWD");
     db = ccnet_key_file_get_string (session->keyf, "Database", "DB");
 
-    if (!host) {
-        g_warning ("DB host not set in config.\n");
-        return -1;
-    }
     if (!user) {
         g_warning ("DB user not set in config.\n");
         return -1;
@@ -177,7 +173,12 @@ static int init_mysql_database (CcnetSession *session)
         g_clear_error (&error);
     }
 
-    session->db = ccnet_db_new_mysql (host, port, user, passwd, db, unix_socket, use_ssl, charset, max_connections);
+    if (unix_socket) {session->db = ccnet_db_new_mysql (NULL, 0, user, passwd, db, unix_socket, NULL, charset, max_connections);}
+       else if (host) {session->db = ccnet_db_new_mysql (host, port, user, passwd, db, NULL, use_ssl, charset, max_connections);}
+               else {
+                   g_warning ("DB host or socket not set in config.\n");
+                   return -1;
+               }
     if (!session->db) {
         g_warning ("Failed to open database.\n");
         return -1;


### PR DESCRIPTION
Support connection to Mysql server only Unix socket

Example:
seafile.conf
[database]
type=mysql
db_name=seafile_db
user=seafile
password=secret
unix_socket=/var/run/mysqld/mysqld.sock
port=0
connection_charset = utf8

ccnet.conf
[Database]
ENGINE=mysql
DB=ccnet_db
USER=seafile
PASSWD=secret
UNIX_SOCKET=/var/run/mysqld/mysqld.sock
PORT=0
CONNECTION_CHARSET = utf8

seahub_settings.py
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'NAME': 'seahub_db',
        'USER': 'seafile',
        'PASSWORD': 'secret',
        'HOST':'/var/run/mysqld/mysqld.sock'
    }
}
